### PR TITLE
Add help when no command is specified

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -70,5 +70,12 @@ program
   .action(() => {
       findKontact()
   })
+
+// A Script file atleast takes 3 args, exit with help message if we don't have
+// enough args
+if(process.argv.length < 3) {
+  program.help();
+}
+
 program
   .parse(process.argv)


### PR DESCRIPTION
Prints help when the user invokes the command with no required arguments